### PR TITLE
Iteration-1 Эндпоинты

### DIFF
--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -1,3 +1,9 @@
 package main
 
-func main() {}
+import "shortly/internal/app/server"
+
+func main() {
+	if err := server.Run(); err != nil {
+		panic(err)
+	}
+}

--- a/internal/app/helpers/generator.go
+++ b/internal/app/helpers/generator.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 )
 
-func GenerateShortID() string {
+func GenerateShortCode() string {
 	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	bytes := make([]byte, 8)
 	if _, err := rand.Read(bytes); err != nil {

--- a/internal/app/helpers/generator.go
+++ b/internal/app/helpers/generator.go
@@ -1,0 +1,17 @@
+package helpers
+
+import (
+	"crypto/rand"
+)
+
+func GenerateShortID() string {
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	bytes := make([]byte, 8)
+	if _, err := rand.Read(bytes); err != nil {
+		return "randomID"
+	}
+	for i, b := range bytes {
+		bytes[i] = chars[b%byte(len(chars))]
+	}
+	return string(bytes)
+}

--- a/internal/app/server/handler.go
+++ b/internal/app/server/handler.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"shortly/internal/app/helpers"
+)
+
+func HandleCreateShortLink(res http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(res, "Wrong HTTP method", http.StatusBadRequest)
+		return
+	}
+
+	_, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(res, "Unable to read request body", http.StatusBadRequest)
+		return
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			http.Error(res, "Unable to close reader", http.StatusInternalServerError)
+		}
+	}(req.Body)
+
+	shortID := helpers.GenerateShortID()
+	shortURL := fmt.Sprintf("http://localhost:8080/%s", shortID)
+
+	res.Header().Set("Content-Type", "text/plain")
+	res.WriteHeader(http.StatusCreated)
+	res.Write([]byte(shortURL))
+}
+
+func HandleGetShortLink(res http.ResponseWriter, req *http.Request) {
+	res.Header().Set("Content-Type", "text/plain")
+	http.Redirect(res, req, "https://practicum.yandex.ru/", http.StatusTemporaryRedirect)
+}

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"net/http"
+)
+
+func Run() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", HandleCreateShortLink)
+	mux.HandleFunc("/{id}", HandleGetShortLink)
+
+	err := http.ListenAndServe(":8080", mux)
+	if err != nil {
+		panic(err)
+	}
+	return nil
+}

--- a/internal/app/store/store.go
+++ b/internal/app/store/store.go
@@ -1,0 +1,28 @@
+package store
+
+import "sync"
+
+type URLStore struct {
+	m map[string]string
+	sync.RWMutex
+}
+
+func NewURLStore() *URLStore {
+	return &URLStore{
+		m: make(map[string]string),
+	}
+}
+
+func (store *URLStore) Set(shortCode, longURL string) {
+	store.Lock()
+	defer store.Unlock()
+	store.m[shortCode] = longURL
+}
+
+func (store *URLStore) Get(shortCode string) (string, bool) {
+	store.RLock()
+	defer store.RUnlock()
+	longURL, found := store.m[shortCode]
+
+	return longURL, found
+}


### PR DESCRIPTION
### Эндпоинт с методом POST /
Сервер принимает в теле запроса строку URL как text/plain и возвращает ответ с кодом 201 и сокращённым URL как text/plain.

Пример запроса к серверу:

```
POST / HTTP/1.1
Host: localhost:8080
Content-Type: text/plain

https://practicum.yandex.ru/
```

Пример ответа от сервера:

```
HTTP/1.1 201 Created
Content-Type: text/plain
Content-Length: 30

http://localhost:8080/EwHXdJfB
```


```
curl -X POST http://localhost:8080/ -H "Content-Type: text/plain" -d "https://practicum.yandex.ru/"
http://localhost:8080/quziEE72
```

### Эндпоинт с методом GET /{id}

где id — идентификатор сокращённого URL (например, /EwHXdJfB). В случае успешной обработки запроса сервер возвращает ответ с кодом 307 и оригинальным URL в HTTP-заголовке Location.

Пример запроса к серверу:

```
GET /EwHXdJfB HTTP/1.1
Host: localhost:8080
Content-Type: text/plain 
```

Пример ответа от сервера:

```
HTTP/1.1 307 Temporary Redirect
Location: https://practicum.yandex.ru/
```


```
curl GET http://localhost:8080/quziEE72 -H "Content-Type: text/plain"
https://practicum.yandex.ru/
```

На любой некорректный запрос сервер должен возвращать ответ с кодом 400.
