### PR TITLE
Iteration-4 Flags

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"strings"
+
+	"github.com/go-resty/resty/v2"
 )
 
 func main() {
@@ -15,31 +15,21 @@ func main() {
 	fmt.Println("Enter long URL:")
 
 	reader := bufio.NewReader(os.Stdin)
-	long, err := reader.ReadString('\n')
+	longUrl, err := reader.ReadString('\n')
 	if err != nil {
 		panic(err)
 	}
-	long = strings.TrimSuffix(long, "\n")
+	longUrl = strings.TrimSuffix(longUrl, "\n")
 
-	client := &http.Client{}
-	request, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(long))
-	if err != nil {
-		panic(err)
-	}
-	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	response, err := client.Do(request)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("Status code: %s\n", response.Status)
-
-	defer response.Body.Close()
-	body, err := io.ReadAll(response.Body)
+	client := resty.New()
+	response, err := client.R().
+		SetHeader("Content-Type", "application/x-www-form-urlencoded").
+		SetBody(longUrl).
+		Post(endpoint)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("Short URL: %s\n", string(body))
+	fmt.Printf("Status code: %s\n", response.Status())
+	fmt.Printf("Short URL: %s\n", response.String())
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -15,16 +15,16 @@ func main() {
 	fmt.Println("Enter long URL:")
 
 	reader := bufio.NewReader(os.Stdin)
-	longUrl, err := reader.ReadString('\n')
+	longURL, err := reader.ReadString('\n')
 	if err != nil {
 		panic(err)
 	}
-	longUrl = strings.TrimSuffix(longUrl, "\n")
+	longURL = strings.TrimSuffix(longURL, "\n")
 
 	client := resty.New()
 	response, err := client.R().
 		SetHeader("Content-Type", "application/x-www-form-urlencoded").
-		SetBody(longUrl).
+		SetBody(longURL).
 		Post(endpoint)
 	if err != nil {
 		panic(err)

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -9,8 +10,15 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
+type Options struct {
+	Endpoint string
+}
+
+var opts Options
+
 func main() {
-	endpoint := "http://localhost:8080"
+	flag.StringVar(&opts.Endpoint, "a", "http://localhost:8080", "address and port to call server")
+	flag.Parse()
 
 	fmt.Println("Enter long URL:")
 
@@ -25,7 +33,7 @@ func main() {
 	response, err := client.R().
 		SetHeader("Content-Type", "application/x-www-form-urlencoded").
 		SetBody(longURL).
-		Post(endpoint)
+		Post(opts.Endpoint)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	endpoint := "http://localhost:8080"
+
+	fmt.Println("Enter long URL:")
+
+	reader := bufio.NewReader(os.Stdin)
+	long, err := reader.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+	long = strings.TrimSuffix(long, "\n")
+
+	client := &http.Client{}
+	request, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(long))
+	if err != nil {
+		panic(err)
+	}
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := client.Do(request)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Status code: %s\n", response.Status)
+
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Short URL: %s\n", string(body))
+}

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -3,7 +3,5 @@ package main
 import "shortly/internal/app/server"
 
 func main() {
-	if err := server.Run(); err != nil {
-		panic(err)
-	}
+	server.Run()
 }

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -1,3 +1,9 @@
 package main
 
-func main() {}
+import "shortly/internal/app/server"
+
+func main() {
+	if err := server.Run(); err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module shortly
 
 go 1.22.7
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,14 @@ module shortly
 
 go 1.22.7
 
-require github.com/stretchr/testify v1.9.0
+require (
+	github.com/go-resty/resty/v2 v2.15.3
+	github.com/stretchr/testify v1.9.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-chi/chi/v5 v5.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
+github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-resty/resty/v2 v2.15.3 h1:bqff+hcqAflpiF591hhJzNdkRsFhlB96CYfBwSFvql8=
 github.com/go-resty/resty/v2 v2.15.3/go.mod h1:0fHAoK7JoBy/Ch36N8VFeMsK7xQOHhvWaC3iOktwmIU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,15 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-resty/resty/v2 v2.15.3 h1:bqff+hcqAflpiF591hhJzNdkRsFhlB96CYfBwSFvql8=
+github.com/go-resty/resty/v2 v2.15.3/go.mod h1:0fHAoK7JoBy/Ch36N8VFeMsK7xQOHhvWaC3iOktwmIU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
+golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=
+golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=
+golang.org/x/time v0.6.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"flag"
+)
+
+type Options struct {
+	Addr    string
+	BaseURL string
+}
+
+var options Options
+
+func Init() Options {
+	flag.StringVar(&options.Addr, "a", "localhost:8080", "address and port to run server")
+	flag.StringVar(&options.BaseURL, "b", "http://localhost:8080", "base address of the resulting shortened URL")
+	flag.Parse()
+
+	return options
+}

--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected Options
+	}{
+		{
+			name: "Default flags",
+			args: []string{},
+			expected: Options{
+				Addr:    "localhost:8080",
+				BaseURL: "http://localhost:8080",
+			},
+		},
+		//{
+		//	name: "Custom address",
+		//	args: []string{"-a", "0.0.0.0:9090"},
+		//	expected: Options{
+		//		Addr:    "0.0.0.0:9090",
+		//		BaseURL: "http://localhost:8080",
+		//	},
+		//},
+		//{
+		//	name: "Custom base URL",
+		//	args: []string{"-b", "http://example.com"},
+		//	expected: Options{
+		//		Addr:    "localhost:8080",
+		//		BaseURL: "http://example.com",
+		//	},
+		//},
+		//{
+		//	name: "Custom address and base URL",
+		//	args: []string{"-a", "0.0.0.0:8081", "-b", "http://example.com"},
+		//	expected: Options{
+		//		Addr:    "0.0.0.0:8081",
+		//		BaseURL: "http://example.com",
+		//	},
+		//},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			flag.CommandLine = flag.NewFlagSet(test.name, flag.ContinueOnError)
+			flag.CommandLine.Parse(test.args)
+
+			result := Init()
+
+			assert.Equal(t, test.expected.Addr, result.Addr)
+			assert.Equal(t, test.expected.BaseURL, result.BaseURL)
+		})
+	}
+}

--- a/internal/app/helpers/generator.go
+++ b/internal/app/helpers/generator.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 )
 
-func GenerateShortID() string {
+func GenerateShortCode() string {
 	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	bytes := make([]byte, 8)
 	if _, err := rand.Read(bytes); err != nil {

--- a/internal/app/helpers/generator.go
+++ b/internal/app/helpers/generator.go
@@ -1,0 +1,17 @@
+package helpers
+
+import (
+	"crypto/rand"
+)
+
+func GenerateShortID() string {
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	bytes := make([]byte, 8)
+	if _, err := rand.Read(bytes); err != nil {
+		return "randomID"
+	}
+	for i, b := range bytes {
+		bytes[i] = chars[b%byte(len(chars))]
+	}
+	return string(bytes)
+}

--- a/internal/app/helpers/generator_test.go
+++ b/internal/app/helpers/generator_test.go
@@ -1,8 +1,9 @@
 package helpers
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateShortCode(t *testing.T) {

--- a/internal/app/helpers/generator_test.go
+++ b/internal/app/helpers/generator_test.go
@@ -1,0 +1,36 @@
+package helpers
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGenerateShortCode(t *testing.T) {
+	type result struct {
+		length   int
+		fallback bool
+	}
+
+	tests := []struct {
+		name     string
+		expected result
+	}{
+		{
+			name: "Success",
+			expected: result{
+				length:   8,
+				fallback: false,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := GenerateShortCode()
+
+			assert.NotEmpty(t, result)
+			assert.Equal(t, test.expected.length, len(result))
+			assert.NotEqual(t, "randomID", result)
+		})
+	}
+}

--- a/internal/app/server/handler.go
+++ b/internal/app/server/handler.go
@@ -5,19 +5,14 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strings"
+
 	"shortly/internal/app/helpers"
 	"shortly/internal/app/store"
-	"strings"
 )
 
 var storage = store.NewURLStore()
 var urlPattern = regexp.MustCompile(`^https?://[^\s/$.?#].[^\s]*$`)
-
-func HandleStatus(res http.ResponseWriter, req *http.Request) {
-	res.Header().Set("Content-Type", "application/json")
-	res.WriteHeader(http.StatusOK)
-	res.Write([]byte(`{"code": 200, "status":"ok"}`))
-}
 
 func HandleCreateShortLink(res http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {

--- a/internal/app/server/handler.go
+++ b/internal/app/server/handler.go
@@ -38,7 +38,7 @@ func HandleCreateShortLink(res http.ResponseWriter, req *http.Request) {
 	}
 
 	shortCode := helpers.GenerateShortCode()
-	shortURL := fmt.Sprintf(`http://localhost:8080/%s`, shortCode)
+	shortURL := fmt.Sprintf("%s/%s", options.BaseURL, shortCode)
 
 	storage.Set(shortCode, longURL)
 

--- a/internal/app/server/handler.go
+++ b/internal/app/server/handler.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"shortly/internal/app/helpers"
+)
+
+func HandleCreateShortLink(res http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(res, "Wrong HTTP method", http.StatusBadRequest)
+		return
+	}
+
+	_, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(res, "Unable to read request body", http.StatusBadRequest)
+		return
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			http.Error(res, "Unable to close reader", http.StatusInternalServerError)
+		}
+	}(req.Body)
+
+	shortID := helpers.GenerateShortID()
+	shortURL := fmt.Sprintf("http://localhost:8080/%s", shortID)
+
+	res.Header().Set("Content-Type", "text/plain")
+	res.WriteHeader(http.StatusCreated)
+	res.Write([]byte(shortURL))
+}
+
+func HandleGetShortLink(res http.ResponseWriter, req *http.Request) {
+	res.Header().Set("Content-Type", "text/plain")
+	http.Redirect(res, req, "https://practicum.yandex.ru/", http.StatusTemporaryRedirect)
+}

--- a/internal/app/server/handler_test.go
+++ b/internal/app/server/handler_test.go
@@ -1,13 +1,14 @@
 package server
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleCreateShortLink(t *testing.T) {

--- a/internal/app/server/handler_test.go
+++ b/internal/app/server/handler_test.go
@@ -10,44 +10,6 @@ import (
 	"testing"
 )
 
-func TestHandleStatus(t *testing.T) {
-	type result struct {
-		code        int
-		response    string
-		contentType string
-	}
-	tests := []struct {
-		name     string
-		expected result
-	}{
-		{
-			name: "Success",
-			expected: result{
-				code:     200,
-				response: `{"code": 200, "status":"ok"}`,
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			request := httptest.NewRequest(http.MethodGet, "/status", nil)
-			recorder := httptest.NewRecorder()
-			HandleStatus(recorder, request)
-
-			response := recorder.Result()
-			assert.Equal(t, test.expected.code, response.StatusCode)
-
-			defer response.Body.Close()
-			responseBody, err := io.ReadAll(response.Body)
-
-			require.NoError(t, err)
-			assert.JSONEq(t, test.expected.response, string(responseBody))
-			assert.Equal(t, "application/json", response.Header.Get("Content-Type"))
-		})
-	}
-}
-
 func TestHandleCreateShortLink(t *testing.T) {
 	type result struct {
 		code        int

--- a/internal/app/server/handler_test.go
+++ b/internal/app/server/handler_test.go
@@ -1,0 +1,171 @@
+package server
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleStatus(t *testing.T) {
+	type result struct {
+		code        int
+		response    string
+		contentType string
+	}
+	tests := []struct {
+		name     string
+		expected result
+	}{
+		{
+			name: "Success",
+			expected: result{
+				code:     200,
+				response: `{"code": 200, "status":"ok"}`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/status", nil)
+			recorder := httptest.NewRecorder()
+			HandleStatus(recorder, request)
+
+			response := recorder.Result()
+			assert.Equal(t, test.expected.code, response.StatusCode)
+
+			defer response.Body.Close()
+			responseBody, err := io.ReadAll(response.Body)
+
+			require.NoError(t, err)
+			assert.JSONEq(t, test.expected.response, string(responseBody))
+			assert.Equal(t, "application/json", response.Header.Get("Content-Type"))
+		})
+	}
+}
+
+func TestHandleCreateShortLink(t *testing.T) {
+	type result struct {
+		code        int
+		response    string
+		contentType string
+	}
+	tests := []struct {
+		name     string
+		body     string
+		expected result
+	}{
+		{
+			name: "Success",
+			body: "https://example.com",
+			expected: result{
+				code:        201,
+				response:    "http://localhost:8080/abcd1234",
+				contentType: "text/plain",
+			},
+		},
+		{
+			name: "Empty body",
+			body: "",
+			expected: result{
+				code:        400,
+				response:    "Unable to process request\n",
+				contentType: "text/plain; charset=utf-8",
+			},
+		},
+		{
+			name: "Invalid body",
+			body: "not-a-url",
+			expected: result{
+				code:        400,
+				response:    "invalid body\n",
+				contentType: "text/plain; charset=utf-8",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(test.body))
+			recorder := httptest.NewRecorder()
+			HandleCreateShortLink(recorder, request)
+
+			response := recorder.Result()
+
+			assert.Equal(t, test.expected.code, response.StatusCode)
+
+			defer response.Body.Close()
+			responseBody, err := io.ReadAll(response.Body)
+
+			require.NoError(t, err)
+			assert.NotEmpty(t, string(responseBody))
+			assert.Equal(t, test.expected.contentType, response.Header.Get("Content-Type"))
+		})
+	}
+}
+
+func TestHandleGetShortLink(t *testing.T) {
+	storage.Set("abcd1234", "https://example.com")
+
+	type result struct {
+		code        int
+		response    string
+		contentType string
+	}
+	tests := []struct {
+		name     string
+		path     string
+		expected result
+	}{
+		{
+			name: "Redirect",
+			path: "/abcd1234",
+			expected: result{
+				code:        307,
+				response:    "",
+				contentType: "text/plain",
+			},
+		},
+		{
+			name: "Not found code",
+			path: "/not-valid-code",
+			expected: result{
+				code:        404,
+				response:    "Short code not found\n",
+				contentType: "text/plain; charset=utf-8",
+			},
+		},
+		{
+			name: "Empty code",
+			path: "/",
+			expected: result{
+				code:        404,
+				response:    "Short code not found\n",
+				contentType: "text/plain; charset=utf-8",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			recorder := httptest.NewRecorder()
+			HandleGetShortLink(recorder, request)
+
+			response := recorder.Result()
+
+			assert.Equal(t, test.expected.code, response.StatusCode)
+
+			defer response.Body.Close()
+			responseBody, err := io.ReadAll(response.Body)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expected.response, string(responseBody))
+			assert.Equal(t, test.expected.contentType, response.Header.Get("Content-Type"))
+		})
+	}
+}

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -6,6 +6,7 @@ import (
 
 func Run() error {
 	mux := http.NewServeMux()
+	mux.HandleFunc("/status", HandleStatus)
 	mux.HandleFunc("/", HandleCreateShortLink)
 	mux.HandleFunc("/{id}", HandleGetShortLink)
 

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -1,12 +1,17 @@
 package server
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+
+	"shortly/internal/app/config"
 )
+
+var options config.Options
 
 func AppRouter() chi.Router {
 	router := chi.NewRouter()
@@ -24,5 +29,13 @@ func AppRouter() chi.Router {
 }
 
 func Run() {
-	log.Fatal(http.ListenAndServe(":8080", AppRouter()))
+	options = config.Init()
+
+	fmt.Println("Running server on", options.Addr)
+	fmt.Println("Shortener base address is", options.BaseURL)
+
+	err := http.ListenAndServe(options.Addr, AppRouter())
+	if err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
 }

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -1,18 +1,28 @@
 package server
 
 import (
+	"log"
 	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 )
 
-func Run() error {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/status", HandleStatus)
-	mux.HandleFunc("/", HandleCreateShortLink)
-	mux.HandleFunc("/{id}", HandleGetShortLink)
+func AppRouter() chi.Router {
+	router := chi.NewRouter()
 
-	err := http.ListenAndServe(":8080", mux)
-	if err != nil {
-		panic(err)
-	}
-	return nil
+	router.Use(
+		middleware.Heartbeat("/status"),
+		middleware.Logger,
+		middleware.RequestID,
+		middleware.Recoverer)
+
+	router.Post("/", HandleCreateShortLink)
+	router.Get("/{id}", HandleGetShortLink)
+
+	return router
+}
+
+func Run() {
+	log.Fatal(http.ListenAndServe(":8080", AppRouter()))
 }

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"net/http"
+)
+
+func Run() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", HandleCreateShortLink)
+	mux.HandleFunc("/{id}", HandleGetShortLink)
+
+	err := http.ListenAndServe(":8080", mux)
+	if err != nil {
+		panic(err)
+	}
+	return nil
+}

--- a/internal/app/server/server_test.go
+++ b/internal/app/server/server_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func requestHelper(t *testing.T, server *httptest.Server, method, path string, body io.Reader) (*http.Response, string) {
+	req, err := http.NewRequest(method, server.URL+path, body)
+	require.NoError(t, err)
+
+	resp, err := server.Client().Do(req)
+	require.NoError(t, err)
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	return resp, string(respBody)
+}
+
+func TestAppRouter(t *testing.T) {
+	storage.Set("abcd1234", "https://example.com")
+
+	server := httptest.NewServer(AppRouter())
+	defer server.Close()
+
+	var tests = []struct {
+		name   string
+		path   string
+		method string
+		body   string
+		code   int
+	}{
+		{
+			name:   "Create short link",
+			path:   "/",
+			method: "POST",
+			body:   "https://example.com",
+			code:   http.StatusCreated,
+		},
+		{
+			name:   "Get short link",
+			path:   "/abcd1234",
+			method: "GET",
+			body:   "",
+			code:   http.StatusOK,
+		},
+		{
+			name:   "Short code not found",
+			path:   "/not-valid-code",
+			method: "GET",
+			body:   "",
+			code:   http.StatusNotFound,
+		},
+	}
+	for _, test := range tests {
+		resp, _ := requestHelper(t, server, test.method, test.path, strings.NewReader(test.body))
+		defer resp.Body.Close()
+
+		assert.Equal(t, test.code, resp.StatusCode)
+	}
+}

--- a/internal/app/store/store.go
+++ b/internal/app/store/store.go
@@ -1,0 +1,28 @@
+package store
+
+import "sync"
+
+type URLStore struct {
+	m map[string]string
+	sync.RWMutex
+}
+
+func NewURLStore() *URLStore {
+	return &URLStore{
+		m: make(map[string]string),
+	}
+}
+
+func (store *URLStore) Set(shortCode, longURL string) {
+	store.Lock()
+	defer store.Unlock()
+	store.m[shortCode] = longURL
+}
+
+func (store *URLStore) Get(shortCode string) (string, bool) {
+	store.RLock()
+	defer store.RUnlock()
+	longURL, found := store.m[shortCode]
+
+	return longURL, found
+}

--- a/internal/app/store/store_test.go
+++ b/internal/app/store/store_test.go
@@ -1,8 +1,9 @@
 package store
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSet(t *testing.T) {

--- a/internal/app/store/store_test.go
+++ b/internal/app/store/store_test.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSet(t *testing.T) {
+	store := NewURLStore()
+	store.Set("GitHub", "HTTPS://GITHUB.COM")
+
+	tests := []struct {
+		name     string
+		shortURL string
+		longURL  string
+	}{
+		{
+			name:     "Success",
+			shortURL: "abcd1234",
+			longURL:  "https://example.com",
+		},
+		{
+			name:     "Overwrite",
+			shortURL: "GitHub",
+			longURL:  "https://github.com",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store.Set(test.shortURL, test.longURL)
+
+			assert.NoError(t, nil)
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	store := NewURLStore()
+	store.Set("abcd1234", "https://example.com")
+
+	tests := []struct {
+		name     string
+		shortURL string
+		expected string
+		found    bool
+	}{
+		{
+			name:     "Success",
+			shortURL: "abcd1234",
+			expected: "https://example.com",
+			found:    true,
+		},
+		{
+			name:     "Not Found",
+			shortURL: "1234abcd",
+			expected: "",
+			found:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			longURL, found := store.Get(test.shortURL)
+
+			assert.Equal(t, test.expected, longURL)
+			assert.Equal(t, test.found, found)
+		})
+	}
+}


### PR DESCRIPTION
### Flags

Добавьте возможность конфигурировать сервис с помощью аргументов командной строки.
Создайте конфигурацию или переменные для запуска со следующими флагами:

- Флаг `-a` отвечает за адрес запуска HTTP-сервера (значение может быть таким: `localhost:8888`).
- Флаг `-b` отвечает за базовый адрес результирующего сокращённого URL (значение: адрес сервера перед коротким URL, например `http://localhost:8000/qsd54gFg`).