### PR TITLE
feat(docs): Add Swagger documentation for Shortly API

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,6 +25,7 @@ linters:
 
 issues:
   exclude-dirs:
+    - docs
     - vendor
   exclude-rules:
     - path: _test\.go

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,0 +1,94 @@
+openapi: 3.1.0
+info:
+  title: Shortly API
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080
+paths:
+  /health:
+    get:
+      summary: Health check
+      description: Check service health
+      responses:
+        '200':
+          description: Service is up and running
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Health check message
+        '500':
+          description: Internal Server Error
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Error message
+  /:
+    post:
+      summary: Create a short link
+      description: Accepts a plain text URL and returns a short URL
+      requestBody:
+        description: Original URL to be shortened
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              format: uri
+      responses:
+        '201':
+          description: Short link created successfully
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Short URL
+        '400':
+          description: Bad Request
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Error message
+        '500':
+          description: Internal Server Error
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Error message
+  '/{id}':
+    get:
+      summary: Redirect to the original URL
+      description: Retrieves the original URL associated with the short code and redirects
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Short code of the URL
+      responses:
+        '307':
+          description: Temporary Redirect to the original URL
+          headers:
+            Location:
+              description: The URL to redirect to
+              schema:
+                type: string
+                format: uri
+        '404':
+          description: Short link not found
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Error message
+        '500':
+          description: Internal Server Error
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Error message


### PR DESCRIPTION
Introduced a new swagger.yaml file to provide OpenAPI specifications for the Shortly API, including endpoints for health check, URL shortening, and redirection.