### PR TITLE
chore(gitignore): Add staticlint binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Binaries
 cmd/shortener/main
 cmd/shortener/shortener
+cmd/staticlint/staticlint
 
 # Dependency directories (remove the comment below to include it)
 vendor/


### PR DESCRIPTION
Updated .gitignore to include the staticlint binary to prevent it from being tracked